### PR TITLE
fix: postgres probe args, db service port, cert templates + production env structure

### DIFF
--- a/charts/freelight-dao/0.5.0/templates/certificate.yaml
+++ b/charts/freelight-dao/0.5.0/templates/certificate.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.certManager.enabled }}
+{{- if .Values.certManager.enabled }}
 {{- $fullName := include "freelight-dao.fullname" . -}}
 {{- if .Values.freelightDAO_frontend.enabled -}}
 apiVersion: cert-manager.io/v1
@@ -8,10 +8,15 @@ metadata:
 spec:
   secretName: {{ $fullName }}-frontend-tls
   issuerRef:
+    {{- if .Values.certManager.clusterIssuer }}
+    kind: ClusterIssuer
+    name: {{ .Values.certManager.clusterIssuer }}
+    {{- else }}
     name: {{ $fullName }}-frontend-issuer
+    {{- end }}
   dnsNames:
-  {{- range .Values.freelightDAO_frontend.ingress.hosts }}
-    - {{ .host | quote }}
+  {{- range .Values.freelightDAO_frontend.httpRoute.hostnames }}
+    - {{ . | quote }}
   {{- end }}
 ---
 {{- end -}}
@@ -23,10 +28,15 @@ metadata:
 spec:
   secretName: {{ $fullName }}-tls
   issuerRef:
+    {{- if .Values.certManager.clusterIssuer }}
+    kind: ClusterIssuer
+    name: {{ .Values.certManager.clusterIssuer }}
+    {{- else }}
     name: {{ $fullName }}-issuer
+    {{- end }}
   dnsNames:
-  {{- range .Values.ingress.hosts }}
-    - {{ .host | quote }}
+  {{- range .Values.freelightDAO_API.httpRoute.hostnames }}
+    - {{ . | quote }}
   {{- end }}
 ---
 apiVersion: cert-manager.io/v1
@@ -36,10 +46,15 @@ metadata:
 spec:
   secretName: {{ $fullName }}-dicebear-tls
   issuerRef:
+    {{- if .Values.certManager.clusterIssuer }}
+    kind: ClusterIssuer
+    name: {{ .Values.certManager.clusterIssuer }}
+    {{- else }}
     name: {{ $fullName }}-dicebear-issuer
+    {{- end }}
   dnsNames:
-  {{- range .Values.dicebear.ingress.hosts }}
-    - {{ .host | quote }}
+  {{- range .Values.dicebear.httpRoute.hostnames }}
+    - {{ . | quote }}
   {{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/freelight-dao/0.5.0/templates/issuer.yaml
+++ b/charts/freelight-dao/0.5.0/templates/issuer.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.ingress.certManager.enabled }}
-{{- if not .Values.ingress.certManager.clusterIssuer }}
+{{- if .Values.certManager.enabled }}
+{{- if not .Values.certManager.clusterIssuer }}
 {{- $fullName := include "freelight-dao.fullname" . -}}
 {{- if .Values.freelightDAO_frontend.enabled -}}
 apiVersion: cert-manager.io/v1
@@ -8,15 +8,15 @@ metadata:
   name: {{ $fullName }}-frontend-issuer
 spec:
   acme:
-    email: {{ .Values.ingress.certManager.email }}
+    email: {{ .Values.certManager.email }}
     server: https://acme-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
       name: {{ $fullName }}-frontend-private-key
     solvers:
     - selector: {}
-      {{- if eq .Values.ingress.certManager.solver "dns01" }}
+      {{- if eq .Values.certManager.solver "dns01" }}
       dns01:
-        {{- toYaml .Values.ingress.certManager.dns01 | nindent 8 }}
+        {{- toYaml .Values.certManager.dns01 | nindent 8 }}
       {{- else }}
       http01:
         ingress:
@@ -31,15 +31,15 @@ metadata:
   name: {{ $fullName }}-issuer
 spec:
   acme:
-    email: {{ .Values.ingress.certManager.email }}
+    email: {{ .Values.certManager.email }}
     server: https://acme-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
       name: {{ $fullName }}-private-key
     solvers:
     - selector: {}
-      {{- if eq .Values.ingress.certManager.solver "dns01" }}
+      {{- if eq .Values.certManager.solver "dns01" }}
       dns01:
-        {{- toYaml .Values.ingress.certManager.dns01 | nindent 8 }}
+        {{- toYaml .Values.certManager.dns01 | nindent 8 }}
       {{- else }}
       http01:
         ingress:
@@ -52,15 +52,15 @@ metadata:
   name: {{ $fullName }}-dicebear-issuer
 spec:
   acme:
-    email: {{ .Values.ingress.certManager.email }}
+    email: {{ .Values.certManager.email }}
     server: https://acme-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
       name: {{ $fullName }}-dicebear-private-key
     solvers:
     - selector: {}
-      {{- if eq .Values.ingress.certManager.solver "dns01" }}
+      {{- if eq .Values.certManager.solver "dns01" }}
       dns01:
-        {{- toYaml .Values.ingress.certManager.dns01 | nindent 8 }}
+        {{- toYaml .Values.certManager.dns01 | nindent 8 }}
       {{- else }}
       http01:
         ingress:

--- a/charts/freelight-dao/0.5.0/templates/postgres-statefulset.yaml
+++ b/charts/freelight-dao/0.5.0/templates/postgres-statefulset.yaml
@@ -46,9 +46,6 @@ spec:
                 - {{ .Values.database.username | quote }}
                 - -d
                 - {{ .Values.database.schema | quote }}
-                - ping
-                - -h
-                - localhost
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
@@ -62,9 +59,6 @@ spec:
                 - {{ .Values.database.username | quote }}
                 - -d
                 - {{ .Values.database.schema | quote }}
-                - ping
-                - -h
-                - localhost
             initialDelaySeconds: 5
             periodSeconds: 2
             timeoutSeconds: 1
@@ -77,6 +71,8 @@ spec:
               value: "{{ .Values.database.username }}"
             - name: POSTGRES_PASSWORD
               value: "{{ .Values.database.password }}"
+            - name: PGDATA
+              value: "/var/lib/postgresql/data/pgdata"
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/freelight-dao/0.5.0/templates/service.yaml
+++ b/charts/freelight-dao/0.5.0/templates/service.yaml
@@ -45,7 +45,7 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: 3306
+    - port: 5432
       targetPort: database
       protocol: TCP
       name: database

--- a/charts/freelight-dao/0.6.0/templates/service.yaml
+++ b/charts/freelight-dao/0.6.0/templates/service.yaml
@@ -45,7 +45,7 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: 3306
+    - port: 5432
       targetPort: database
       protocol: TCP
       name: database


### PR DESCRIPTION
## Summary

### Bug Fixes (discovered while restoring staging)
- **postgres-statefulset**: Removed invalid `ping -h localhost` args from `pg_isready` liveness/readiness probes — these caused the DB pod to crash-loop
- **service.yaml**: Fixed DB service port from `3306` (MySQL) to `5432` (Postgres)
- **certificate.yaml / issuer.yaml**: Fixed template refs to use `certManager.*` instead of `ingress.certManager.*`; updated hostname refs to use `httpRoute.hostnames`

### Production Env
- Added `env.production/freelight-dao/custom-values.yaml` locally (gitignored — contains secrets)
- Production config uses non-staging image tags, prod hostnames (`app.freelight.org`, `api.freelight.org`), swagger/debug off, tighter resource limits
- All secrets are `CHANGEME_*` placeholders to be filled before deploying